### PR TITLE
:bug: (EL) switch to proper distro docker package

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 
 galaxy_info:
   author: 'Adfinis SyGroup AG'
-  description: 'Install docker-ce on a host'
+  description: 'Install docker on a host'
   company: 'Adfinis SyGroup AG'
   license: 'GNU General Public License v3'
   min_ansible_version: '2.4.0'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -7,10 +7,39 @@
     owner: root
     group: root
     mode: 0600
+  when: ansible_os_family == 'Debian'
+
+- name: add docker storage setup
+  template:
+    src: etc/sysconfig/docker-storage-setup.j2
+    dest: '{{ docker_sysconfig_storage_setup }}'
+    owner: root
+    group: root
+    mode: 0600
     seuser: system_u
     serole: object_r
     setype: etc_t
     selevel: s0
+  register: docker_sysconfig_storage_setup_template
+  when: ansible_os_family == 'RedHat'
+
+- name: perform docker storage setup
+  block:
+  - name: stop docker to run storage setup
+    service:
+      name: '{{ docker_service }}'
+      state: stopped
+
+  - name: run docker-storage-setup
+    command: docker-storage-setup
+
+  - name: start docker after storage setup
+    service:
+      name: '{{ docker_service }}'
+      state: started
+  when:
+    - ansible_os_family == 'RedHat'
+    - docker_sysconfig_storage_setup_template.changed
 
 - name: start and enable docker service
   service:

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -5,21 +5,6 @@
     name: '{{ docker_package_dependencies }}'
     state: present
 
-- name: configure docker-ce rpm key
-  rpm_key:
-    key: '{{ docker_rpm_key }}'
-    state: present
-  when: ansible_os_family == 'RedHat'
-
-- name: add docker-ce yum repository
-  yum_repository:
-    name: docker-ce
-    description: Docker Community Edition
-    baseurl: '{{ docker_rpm_repo }}'
-    gpgcheck: yes
-    gpgkey: '{{ docker_rpm_key }}'
-  when: ansible_os_family == 'RedHat'
-
 - name: configure docker-ce apt key
   apt_key:
     url: '{{ docker_apt_key }}'

--- a/templates/etc/sysconfig/docker-storage-setup.j2
+++ b/templates/etc/sysconfig/docker-storage-setup.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+
+DEVS={{ docker_storage_device }}
+VG={{ docker_vg_name }}
+STORAGE_DRIVER=overlay2
+CONTAINER_ROOT_LV_NAME={{ docker_lv_name }}
+CONTAINER_ROOT_LV_SIZE={{ docker_lv_size }}
+CONTAINER_ROOT_LV_MOUNT_PATH={{ docker_lv_mount }}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,12 +5,19 @@ docker_package_dependencies:
   - device-mapper-persistent-data
   - lvm2
 
-docker_rpm_key: 'https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg'
-docker_rpm_repo: 'https://download.docker.com/linux/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}/$basearch/stable'
-
 docker_packages:
-  - docker-ce
+  - docker
 
 docker_service: docker
 
-docker_daemon_configuration: /etc/docker/daemon.json
+docker_sysconfig_storage_setup: /etc/sysconfig/docker-storage-setup
+
+docker_storage_devices: ~
+
+docker_vg_name: docker-vg
+
+docker_lv_name: dockerlv
+
+docker_lv_size: 100%FREE
+
+docker_lv_mount: /var/lib/docker


### PR DESCRIPTION
##### SUMMARY
This switches to using distro packages in the recommended way on EL. This should make it possible to use this role to install *real* RHEL systems and also help with operational stability.

Fixes #2
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
From my Fedora Dev Env, not that it really matters.
```
ansible 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/lucasb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15 (default, May 16 2018, 17:50:09) [GCC 8.1.1 20180502 (Red Hat 8.1.1-1)]
```


##### ADDITIONAL INFORMATION
It seems the easiesy way to reprod why I'm doing this change now is to schedule some docker heavy jobs on our internal CI platform.