### PR TITLE
Change the cron_file so there will be a file at /etc/cron.d/

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -35,4 +35,3 @@
     cron_file: ansible_docker_prune
     user: root
   when: docker_cleanup_cronjob_enable
-

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -32,4 +32,7 @@
     month: '{{ docker_cleanup_cronjob_month }}'
     weekday: '{{ docker_cleanup_cronjob_weekday }}'
     job: docker system prune -af
+    cron_file: ansible_docker_prune
+    user: root
   when: docker_cleanup_cronjob_enable
+


### PR DESCRIPTION
Instead of letting ansible create the cronjob at /var/spool/cron/root it will now create a file at
/etc/cron.d/ansible_docker_prune

