### PR TITLE
add github action for releasing to ansible galaxy

### DIFF
--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -1,0 +1,15 @@
+---
+name: CI - Release
+
+on:
+  release:
+    types: [created, edited, published, released]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: galaxy
+        uses: robertdebock/galaxy-action@1.0.1
+        with:
+          galaxy_api_key: ${{ secrets.galaxy_api_key }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR enables us to automatically import new releases of the role in ansible galaxy.
This was previously provided by travis which used a webhook.

This change has the drawback/feature that we have to tag new releases so they are imported into ansible galaxy.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request